### PR TITLE
use the resolveHosts role to allow nodes to resolve other nodes by name....

### DIFF
--- a/roles/commonVars/vars/main.yml
+++ b/roles/commonVars/vars/main.yml
@@ -1,0 +1,2 @@
+---
+domain: testdomain.massive.org.au

--- a/roles/etcHosts/tasks/main.yml
+++ b/roles/etcHosts/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: get_groups_json
+  template: dest=/tmp/groups src=groups.j2
+  run_once: True
+  delegate_to: 127.0.0.1
+
+- name: make hosts data
+  command: ./scripts/makehosts.py /tmp/groups {{ domain }}
+  delegate_to: 127.0.0.1
+  run_once: True
+  register: hosts_data
+               
+- name: write hosts file
+  lineinfile:
+  args:
+    dest: /etc/hosts
+    line: "{{ item }}"
+    state: present
+  sudo: true
+  with_items: hosts_data.stdout_lines

--- a/roles/etcHosts/templates/groups.j2
+++ b/roles/etcHosts/templates/groups.j2
@@ -1,0 +1,4 @@
+{ 
+  "groups": {{ groups | to_nice_json }},
+  "hostvars": {{ hostvars | to_nice_json }}
+}

--- a/roles/resolveHosts/meta/main.yml
+++ b/roles/resolveHosts/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies:
+  - { role: commonVars }
+  - { role: etcHosts }
+


### PR DESCRIPTION
... conifugre the dependenices for resolveHosts to use the role etcHosts if you would like to put all hosts in /etc/hosts or create a new role for a dnsclient if you would prefer
