### PR TITLE
Remove unused the file

### DIFF
--- a/roles/easy-rsa-CA/tasks/buildClientCert.yml
+++ b/roles/easy-rsa-CA/tasks/buildClientCert.yml
@@ -1,8 +1,0 @@
---- 
-- name: "Creating Client certificate"
-  delegate_to: "127.0.0.1"
-  shell: " cd /etc/easy-rsa/2.0; source ./vars; export EASY_RSA=\\\"${EASY_RSA:-.}\\\"; \"$EASY_RSA/pkitool\" --csr {{ client }} ;\"$E ASY_RSA/pkitool\" --sign {{ client }}"
-  args:
-    chdir: /etc/easy-rsa/2.0/keys/
-    creates: client.crt
-


### PR DESCRIPTION
Chris pointed out that easy-rsa-CA/easy-rsa-CA-client is not used and should not be in source. Clean it up.

jupiter
