### PR TITLE
some more tweaks

### DIFF
--- a/roles/easy-rsa-certificate/tasks/buildCert.yml
+++ b/roles/easy-rsa-certificate/tasks/buildCert.yml
@@ -33,7 +33,7 @@
   remote_user: "{{ hostvars[x509_ca_server]['ansible_ssh_user'] }}"
   delegate_to: "{{ x509_ca_server }}"
   shell: rm -rf /etc/easy-rsa/2.0/keys/{{ x509_common_name }}.*
-  when: cert.stat.size == 0
+  when: cert.stat.exists == true and cert.stat.size == 0
 
 - name: "set needcert if cert doesn't match key"
   set_fact: needcert=True

--- a/roles/slurm-build/tasks/main.yml
+++ b/roles/slurm-build/tasks/main.yml
@@ -26,7 +26,7 @@
     creates: /root/rpmbuild/RPMS/x86_64/munge-{{ munge_version }}-1.el6.x86_64.rpm
 
 - name: get slurm
-  shell: wget http://www.schedmd.com/download/latest/slurm-{{ slurm_version }}.tar.bz2
+  shell: wget http://www.schedmd.com/download/archive/slurm-{{ slurm_version }}.tar.bz2
   args:
     chdir: /tmp
     creates: /tmp/slurm-{{ slurm_version }}.tar.bz2

--- a/roles/syncExports/templates/exports.j2
+++ b/roles/syncExports/templates/exports.j2
@@ -1,4 +1,14 @@
+{% set iplist = [] %}
 {% for export in exportList %}
-{{ export.src }} {% for group in groupList %}{% for node in  groups[group.name] %}{{ hostvars[node]['ansible_'+group.interface]['ipv4']['address'] }}(rw,sync,root_squash) {% endfor %}{% endfor %}
+{% for group in groupList %}
+{% for node in groups[group.name] %}
+{% if hostvars[node]['ansible_'+group.interface] is defined %}
+{% if iplist.append(hostvars[node]['ansible_'+group.interface]['ipv4']['address']) %}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endfor %}
+
+{{ export.src }} {% for ip in iplist|unique %}{{ ip }}(rw,sync,root_squash) {% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
Another small set of changes to reduce crashes. 

cert.stat.size will only be defined if cert.stat.exists
Use slurm from the archive (rather than latest) so that everytime a new version is released it doesn't break
changes to exports.j2 mean it won't crash and burn if a node doesn't have an interface specified (having trouble with my OpenVPN being temporarily down)
