### PR TITLE
Revert "add roles"

### DIFF
--- a/roles/cronJob/tasks/main.yml
+++ b/roles/cronJob/tasks/main.yml
@@ -1,7 +1,0 @@
----
-- name: cron job 
-  cron: name={{ item.name }} job={{ item.job }} user= {{ item.user}} hour={{ item.hour }} state=present
-  with_items: 
-    cronJobs 
-  sudo: true
-  when: cronJobs is defined

--- a/roles/extraFiles/tasks/main.yml
+++ b/roles/extraFiles/tasks/main.yml
@@ -1,7 +1,0 @@
----
-- name: extra file symbolic links 
-  file: src={{ item.src }} path={{ item.dest }} state={{ item.type }} force=yes
-  with_items: 
-    extraFiles
-  sudo: true
-  when: extraFiles is defined

--- a/roles/extra_rpms/vars/main.yml
+++ b/roles/extra_rpms/vars/main.yml
@@ -240,5 +240,3 @@ pkgs:
  - postgresql-contrib
  - postgresql-devel
  - environment-modules
- - tcl
- - rsync 


### PR DESCRIPTION
Reverts monash-merc/ansible_cluster_in_a_box#64

This makes me uncomfortable.
cronJob is not a role which any node in the cluster performs, equally extraFiles is not a "role" which any node performs.

If there is an extra file, which needs to be copied in an associated with a cron job, (which I suspect is what your doing here) those two things should form a role in themselves.

for example, since we have NFS home directories, it might make sense to have a provision role, that will run a provisioning script to create home directories prior to someone loging in for the first time. The cronjob and script to do this would both be part of the provision role. Otherwise things are just getting to opaque with everything being defined in the variables.