### PR TITLE
sssd uses the ldapDomain rather than the ansible_domain to template s…

### DIFF
--- a/roles/ldapclient/templates/sssd.j2
+++ b/roles/ldapclient/templates/sssd.j2
@@ -1,6 +1,6 @@
 [sssd]
 config_file_version = 2
-domains = {{ ansible_domain }}
+domains = {{ ldapDomain }}
 services = nss, pam, autofs
 
 [nss]
@@ -9,7 +9,7 @@ filter_groups = slurm, munge
 
 [pam]
 
-[domain/{{ ansible_domain }}]
+[domain/{{ ldapDomain }}]
 ldap_referrals = false
 cache_credentials = false
 entry_cache_timeout=3600


### PR DESCRIPTION
…ssd.conf. Hopefully machines will work with sssd even with domain resolution (hostname -d)